### PR TITLE
Fix DOCKER_HOST_IP for mac

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ You only need to provide the `DOCKER_HOST_IP` environment variable if you want t
 ### When using Docker for Mac
 
 ```
-export DOCKER_HOST_IP=docker.for.mac.localhost
+export DOCKER_HOST_IP=host.docker.internal
 ```
 
 ### When using Docker for Windows


### PR DESCRIPTION
hostname has changed in current mac releases. 
See: 
- https://docs.docker.com/docker-for-mac/networking/#per-container-ip-addressing-is-not-possible
- https://github.com/docker/for-mac/issues/1837